### PR TITLE
Add Unformat, which parses formatted strings (reverse of std::format)

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ as C/C++, as this is not an obstacle to most users.)
 |  [mm_lexer.h](https://github.com/vurtun/mmx)                          | zlib                 |C/C++|**1**| C-esque language lexer
 |  [SLRE](https://github.com/cesanta/slre)                              |_GPLv2_               |C/C++|**1**| regular expression matcher
 |  [tinymemfile](https://github.com/RandyGaul/tinyheaders)              | zlib                 | C++ |**1**| fscanf on in-memory files
+|  [Unformat](https://github.com/adamyaxley/Unformat)                   | **public domain**    | C++ |**1**| parses formatted strings (reverse of std::format)
 
 # profiling
 | library                                                               | license              | API |files| description


### PR DESCRIPTION
Include the link to the library in your description, as well as in the PR itself.
